### PR TITLE
修复一个崩溃

### DIFF
--- a/assists/src/main/java/com/ven/assists/window/AssistsWindowManager.kt
+++ b/assists/src/main/java/com/ven/assists/window/AssistsWindowManager.kt
@@ -201,6 +201,14 @@ object AssistsWindowManager {
             viewList.values.lastOrNull()?.let { it.view.isInvisible = true }
         }
         view.tag = viewTag
+
+        viewList.values.find {
+            return@find view == it.view
+        }?.let {
+            it.view.isVisible = true
+            return it
+        }
+
         windowManager.addView(view, layoutParams)
         if (isTouchable) {
             layoutParams.touchableByLayoutParams()

--- a/simple/src/main/java/com/ven/assists/simple/overlays/OverlayBasic.kt
+++ b/simple/src/main/java/com/ven/assists/simple/overlays/OverlayBasic.kt
@@ -53,7 +53,7 @@ object OverlayBasic : AssistsServiceListener {
                 field = BasicOverlayBinding.inflate(LayoutInflater.from(AssistsService.instance)).apply {
                     //点击
                     btnClick.setOnClickListener {
-                        CoroutineWrapper.launch {
+                        CoroutineWrapper.launch(isMain = true) {
                             AssistsService.instance?.startActivity(Intent(AssistsService.instance, TestActivity::class.java).apply {
                                 flags = Intent.FLAG_ACTIVITY_NEW_TASK
                             })
@@ -63,7 +63,7 @@ object OverlayBasic : AssistsServiceListener {
                     }
                     //手势点击
                     btnGestureClick.setOnClickListener {
-                        CoroutineWrapper.launch {
+                        CoroutineWrapper.launch(isMain = true) {
                             ActivityUtils.getTopActivity()?.startActivity(Intent(AssistsService.instance, TestActivity::class.java).apply {
                                 flags = Intent.FLAG_ACTIVITY_NEW_TASK
                             })
@@ -73,7 +73,7 @@ object OverlayBasic : AssistsServiceListener {
                     }
                     //长按
                     btnLongClick.setOnClickListener {
-                        CoroutineWrapper.launch {
+                        CoroutineWrapper.launch(isMain = true) {
                             ActivityUtils.getTopActivity()?.startActivity(Intent(AssistsService.instance, TestActivity::class.java).apply {
                                 flags = Intent.FLAG_ACTIVITY_NEW_TASK
                             })
@@ -83,7 +83,7 @@ object OverlayBasic : AssistsServiceListener {
                     }
                     //手势长按
                     btnGestureLongClick.setOnClickListener {
-                        CoroutineWrapper.launch {
+                        CoroutineWrapper.launch(isMain = true) {
                             ActivityUtils.getTopActivity()?.startActivity(Intent(AssistsService.instance, TestActivity::class.java).apply {
                                 flags = Intent.FLAG_ACTIVITY_NEW_TASK
                             })


### PR DESCRIPTION

https://github.com/user-attachments/assets/92bf7d2d-7777-4c18-ab3c-afcb5cad9993

（1）修复一个崩溃，崩溃堆栈如下：
```
E  FATAL EXCEPTION: main
Process: com.ven.assists.demo, PID: 9653
java.lang.IllegalStateException: View android.widget.LinearLayout{32829d I.E...... ......ID 0,0-960,960} has already been added to the window manager.
at android.view.WindowManagerGlobal.addView(WindowManagerGlobal.java:370)
at android.view.WindowManagerImpl.addView(WindowManagerImpl.java:168)
at com.ven.assists.window.AssistsWindowManager.add(AssistsWindowManager.kt:204)
at com.ven.assists.window.AssistsWindowManager.add$default(AssistsWindowManager.kt:192)
at com.ven.assists.window.AssistsWindowManager.add(AssistsWindowManager.kt:182)
at com.ven.assists.window.AssistsWindowManager.add$default(AssistsWindowManager.kt:180)
at com.ven.assists.simple.overlays.OverlayBasic.show(OverlayBasic.kt:298)
at com.ven.assists.simple.MainActivity$viewBind$2.invoke$lambda-5$lambda-1(MainActivity.kt:51)
at com.ven.assists.simple.MainActivity$viewBind$2.$r8$lambda$OXXcm36lKmJWfGku88lrCh72ybQ(Unknown Source:0)
at com.ven.assists.simple.MainActivity$viewBind$2$$ExternalSyntheticLambda1.onClick(Unknown Source:0)
at android.view.View.performClick(View.java:7515)
at android.view.View.performClickInternal(View.java:7492)
at android.view.View.-$$Nest$mperformClickInternal(Unknown Source:0)
at android.view.View$PerformClick.run(View.java:29362)
at android.os.Handler.handleCallback(Handler.java:942)
at android.os.Handler.dispatchMessage(Handler.java:99)
at android.os.Looper.loopOnce(Looper.java:201)
at android.os.Looper.loop(Looper.java:288)
at android.app.ActivityThread.main(ActivityThread.java:8181)
at java.lang.reflect.Method.invoke(Native Method)
at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:552)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:946)
D  call killProcess from uid 10745 pid 9653 tid 9653 to kill pid 9653
java.lang.Exception: log killProcess callstack for debug:
at android.os.Process.killProcess(Process.java:1352)
at com.android.internal.os.RuntimeInit$KillApplicationHandler.uncaughtException(RuntimeInit.java:174)
at java.lang.ThreadGroup.uncaughtException(ThreadGroup.java:1073)
at java.lang.ThreadGroup.uncaughtException(ThreadGroup.java:1068)
at java.lang.Thread.dispatchUncaughtException(Thread.java:2306)
```
view已经被addView过了，所以在addView前需要过滤下。

（2）OverlayBasic类里startActivity需要放到Dispatchers.Main